### PR TITLE
Pass traversal to resolve/reject handlers

### DIFF
--- a/traverson-promise.js
+++ b/traverson-promise.js
@@ -35,14 +35,19 @@ function promisify (context, originalMethod) {
 
   var deferred = defer()
   var traversal = void 0
+  var resultWithTraversalDeferred = defer()
 
   var callback = function callback (err, result, _traversal) {
     if (err) {
       err.result = result
       deferred.reject(err)
+      // Pass the error and traversal to reject handler on resultWithTraversal
+      resultWithTraversalDeferred.reject({ error: err, traversal })
     } else {
       traversal = _traversal
       deferred.resolve(result)
+      // Pass the response and traversal to resolve handler on resultWithTraversal
+      resultWithTraversalDeferred.resolve({ result, traversal })
     }
   }
 
@@ -64,6 +69,7 @@ function promisify (context, originalMethod) {
 
   return {
     result: deferred.promise,
+    resultWithTraversal: resultWithTraversalDeferred.promise,
     continue: continueTraversal,
     abort: traversalHandler.abort,
     then: function then () {
@@ -101,3 +107,4 @@ Builder.prototype.delete = Builder.prototype.del = function () {
 }
 
 module.exports = traverson
+


### PR DESCRIPTION
It allows to pass the traversal to resolve handler and call eg. `continue()`:

```
traversonPromise
    .follow('link1')
    .getResource()
    .resultWithTraversal
    .then(({ result, traversal }) => {
      const result1 = result

      return traversal
        .continue()
        .follow('link2')
        .getResource()
        .result
        .then(result => ({ ...result, ...result1 }))
    })
```
